### PR TITLE
Fix another edge case with triple quotes and prefix containing 'r'.

### DIFF
--- a/pybetter/transformers/empty_fstring.py
+++ b/pybetter/transformers/empty_fstring.py
@@ -15,7 +15,7 @@ class TrivialFmtStringTransformer(NoqaAwareTransformer):
             # SimpleString._get_prefix treating everything before quotation
             # marks as a prefix. (sic!)
             return cst.SimpleString(
-                value=f'{updated_node.start.lstrip("f")}{updated_node.parts[0].value}{updated_node.end}'
+                value=f'{updated_node.start.replace("f", "")}{updated_node.parts[0].value}{updated_node.end}'
             )
 
         return original_node

--- a/test.py
+++ b/test.py
@@ -13,13 +13,13 @@ def check_membership(username, allowed=[], banned_sets={}):
 
     for banned in banned_sets:
         if username in banned:
-            return (False, f"""User was banned!""")
+            return (False, rf"""User was \banned!""")
 
     if not username in allowed:
         found = False
 
     if found == False or found != 42 and found == True:
-        return (False, f"User is not allowed!")
+        return (False, fr"User is not \allowed!")
 
     with ctx():
         with recorder() as rec:

--- a/tests/test_trivial_fstring.py
+++ b/tests/test_trivial_fstring.py
@@ -24,6 +24,23 @@ TRIVIAL_FSTRING_IN_TRIPLE_QUOTES = (
     ''',
 )
 
+TRIVIAL_FSTRING_TRIPLE_QUOTES_R_PREFIX_AFTER = (
+    '''
+    fr"""Hello,\bworld!"""
+    ''',
+    '''
+    r"""Hello,\bworld!"""
+    ''',
+)
+
+TRIVIAL_FSTRING_TRIPLE_QUOTES_R_PREFIX_BEFORE = (
+    '''
+    rf"""Hello,\bworld!"""
+    ''',
+    '''
+    r"""Hello,\bworld!"""
+    ''',
+)
 
 FSTRING_WITH_ARGUMENTS = (
     """
@@ -40,17 +57,22 @@ EMPTY_FSTRING = (
 )
 
 
+@pytest.mark.wip
 @pytest.mark.parametrize(
     "original,expected",
     [
         TRIVIAL_FSTRING,
         TRIVIAL_FSTRING_IN_TRIPLE_QUOTES,
+        TRIVIAL_FSTRING_TRIPLE_QUOTES_R_PREFIX_BEFORE,
+        TRIVIAL_FSTRING_TRIPLE_QUOTES_R_PREFIX_AFTER,
         FSTRING_WITH_ARGUMENTS,
         EMPTY_FSTRING,
     ],
     ids=[
         "trivial f-string",
         "trivial f-string in triple quotes",
+        "trivial f-string in triple quotes with 'rf' prefix",
+        "trivial f-string in triple quotes with 'fr' prefix",
         "f-string with arguments",
         "empty f-string",
     ],


### PR DESCRIPTION
Closes #62 

Interestingly enough this also triggers a bug in the current LibCST (0.3.16) - `rf"""Hello, world"""` is a valid string in Python, but trips internal validation inside LibCST.