### PR TITLE
(B008) Properly process `async with` when creating compound `with` statements

### DIFF
--- a/pybetter/transformers/nested_withs.py
+++ b/pybetter/transformers/nested_withs.py
@@ -50,6 +50,11 @@ class NestedWithTransformer(NoqaAwareTransformer):
             if has_inline_comment(candidate_with.body):
                 break
 
+            # There is no meaningful way `async with` can be merged into
+            # the compound `with` statement.
+            if candidate_with.asynchronous:
+                break
+
             compound_items.extend(candidate_with.items)
             final_body = candidate_with.body
 

--- a/tests/test_nested_withs.py
+++ b/tests/test_nested_withs.py
@@ -126,6 +126,26 @@ with logger():
 )
 
 
+ASYNC_WITH_IS_LEFT_ALONE = (
+    """
+with open(fn, "w") as fob:
+    async with make_request() as resp:
+        pass
+    """,
+    NO_CHANGES_MADE,
+)
+
+ASYNC_IN_THE_MIDDLE_PREVENTS_COMPOUNDING = (
+    """
+with a():
+    async with abc():
+        with b():
+            pass 
+    """,
+    NO_CHANGES_MADE,
+)
+
+
 @pytest.mark.parametrize(
     "original,expected",
     [
@@ -139,6 +159,8 @@ with logger():
         UNRELATED_CODE_IS_NOT_PROCESSED,
         SINGLE_WITH_IS_LEFT_ALONE,
         ALIASES_ARE_PRESERVED,
+        ASYNC_WITH_IS_LEFT_ALONE,
+        ASYNC_IN_THE_MIDDLE_PREVENTS_COMPOUNDING,
     ],
     ids=[
         "trivial nested 'with'",
@@ -151,6 +173,8 @@ with logger():
         "unrelated code",
         "single 'with' is left alone",
         "'with' aliases are preserved",
+        "'async with' is left alone",
+        "'async' prevents compounding of 'with's",
     ],
 )
 def test_collapse_of_nested_with_statements(original, expected):


### PR DESCRIPTION

Closes #114.